### PR TITLE
Update Supabase env var names for configuration

### DIFF
--- a/RecettesIndex.Api/Program.cs
+++ b/RecettesIndex.Api/Program.cs
@@ -17,11 +17,10 @@ var builder = new HostBuilder()
     {
         services.AddApplicationInsightsTelemetryWorkerService();
         services.ConfigureFunctionsApplicationInsights();
-        var b = Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Process);
         var supabaseConfig = new SupabaseConfiguration
         {
-            Url = Environment.GetEnvironmentVariable("Supabase.Url", EnvironmentVariableTarget.Process) ?? string.Empty,
-            Key = Environment.GetEnvironmentVariable("Supabase.Key", EnvironmentVariableTarget.Process) ?? string.Empty
+            Url = Environment.GetEnvironmentVariable("SUPABASE_URL", EnvironmentVariableTarget.Process) ?? string.Empty,
+            Key = Environment.GetEnvironmentVariable("SUPABASE_KEY", EnvironmentVariableTarget.Process) ?? string.Empty
         };
 
         services.AddSingleton(provider => new Supabase.Client(supabaseConfig.Url ?? string.Empty, supabaseConfig.Key ?? string.Empty, options));


### PR DESCRIPTION
Updated the environment variable names used in the `SupabaseConfiguration` object. Changed `Supabase.Url` to `SUPABASE_URL` and `Supabase.Key` to `SUPABASE_KEY` to ensure the application retrieves the Supabase URL and key from the new environment variable names.