### PR TITLE
Rename 'Name' to 'Title' in Book class and related files

### DIFF
--- a/RecettesIndex.Api/Data/Converter/BookConverter.cs
+++ b/RecettesIndex.Api/Data/Converter/BookConverter.cs
@@ -7,7 +7,7 @@ public static class BookConverter
         return new Models.Book
         {
             Id = book.Id,
-            Name = book.Name,
+            Title = book.Title,
             Author = book.Author.Convert(),
             CreatedAt = book.CreatedAt
         };
@@ -22,7 +22,7 @@ public static class BookConverter
         return new Shared.Book
         {
             Id = book.Id,
-            Name = book.Name,
+            Title = book.Title,
             Author = book.Author.Convert(),
             CreatedAt = book.CreatedAt
         };

--- a/RecettesIndex.Api/Data/Models/Book.cs
+++ b/RecettesIndex.Api/Data/Models/Book.cs
@@ -9,8 +9,8 @@ public class Book : BaseModel
     [PrimaryKey("id")]
     public int Id { get; set; }
 
-    [Column("name")]
-    public string Name { get; set; } = "";
+    [Column("title")]
+    public string Title { get; set; } = "";
 
     [Column("author")]
     public int? AuthorId { get; set; }

--- a/RecettesIndex.Shared/Book.cs
+++ b/RecettesIndex.Shared/Book.cs
@@ -4,7 +4,7 @@ public record Book
 {
     public int Id { get; set; }
 
-    public required string Name { get; set; }
+    public required string Title { get; set; }
 
     public required Author Author { get; set; }
 

--- a/RecettesIndex/Features/Books/Components/BooksList.razor
+++ b/RecettesIndex/Features/Books/Components/BooksList.razor
@@ -10,7 +10,7 @@
         {
             <tr>
                 <td>
-                    <a href="/bookDetails/@book.Id">@book.Name</a>
+                    <a href="/bookDetails/@book.Id">@book.Title</a>
                 </td>
                 <td>
                     @if (book.Author != null)

--- a/RecettesIndex/Features/Books/Pages/BookDetails.razor
+++ b/RecettesIndex/Features/Books/Pages/BookDetails.razor
@@ -12,7 +12,7 @@ else
 {
     <dl>
         <dt>Titre</dt>
-        <dd>@book.Name</dd>
+        <dd>@book.Title</dd>
         <dt>Auteur</dt>
         <dd>
             @if (book.Author != null)

--- a/RecettesIndex/Features/Recettes/Components/RecettesList.razor
+++ b/RecettesIndex/Features/Recettes/Components/RecettesList.razor
@@ -17,7 +17,7 @@
                 <td>
                     @if (recette.Book != null)
                     {
-                        <a href="/bookDetails/@recette.BookId">@recette.Book.Name</a>
+                        <a href="/bookDetails/@recette.BookId">@recette.Book.Title</a>
                     }
                 </td>
                 <td>

--- a/RecettesIndex/Features/Recettes/Pages/RecetteDetails.razor
+++ b/RecettesIndex/Features/Recettes/Pages/RecetteDetails.razor
@@ -17,7 +17,7 @@ else
         <dd>
             @if (recette.Book != null)
                 {
-                    <a href="/bookDetails/@recette.Book.Id">@recette.Book.Name</a>
+                <a href="/bookDetails/@recette.Book.Id">@recette.Book.Title</a>
                 }
         </dd>
         <dt>Date</dt>


### PR DESCRIPTION
Renamed the 'Name' property to 'Title' in the 'Book' class and updated all relevant parts of the codebase to reflect this change:
- Updated 'Convert' methods in 'BookConverter.cs' for both 'Shared.Book' and 'Models.Book'.
- Replaced 'Name' with 'Title' in 'Book.cs', including the corresponding database column attribute.
- Updated book title display in 'BooksList.razor', 'BookDetails.razor', 'RecettesList.razor', and 'RecetteDetails.razor'.