### PR TITLE
Update MudBlazor, fix null init, and adjust script tags

### DIFF
--- a/RecettesIndex/Layout/MainLayout.razor
+++ b/RecettesIndex/Layout/MainLayout.razor
@@ -25,7 +25,7 @@
 
 @code {
     bool _drawerOpen = true;
-    private MudThemeProvider _mudThemeProvider;
+    private MudThemeProvider _mudThemeProvider = null!;
     private MudTheme? _theme = null;
     private bool _isDarkMode;
 

--- a/RecettesIndex/RecettesIndex.csproj
+++ b/RecettesIndex/RecettesIndex.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.3" PrivateAssets="all" />
-    <PackageReference Include="MudBlazor" Version="7.15.0" />
+    <PackageReference Include="MudBlazor" Version="8.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RecettesIndex/wwwroot/index.html
+++ b/RecettesIndex/wwwroot/index.html
@@ -26,8 +26,9 @@
             <a href="" class="reload">Reload</a>
             <a class="dismiss">🗙</a>
         </div>
-        <script src="_content/MudBlazor/MudBlazor.min.js"></script>
-        <script src="_framework/blazor.webassembly.js"></script>
+    </div>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_framework/blazor.webassembly.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
- Initialize `_mudThemeProvider` in `MainLayout.razor` with a non-null default value using the null-forgiving operator (`null!`).
- Upgrade `MudBlazor` package in `RecettesIndex.csproj` from version `7.15.0` to `8.3.0`.
- Move script tags for `MudBlazor.min.js` and `blazor.webassembly.js` inside the closing `div` tag in `index.html` for proper loading and execution order.